### PR TITLE
Fix adr006 arrow direction

### DIFF
--- a/docs/adrs/adr006-use-event-relations-for-topic-submissions.md
+++ b/docs/adrs/adr006-use-event-relations-for-topic-submissions.md
@@ -100,12 +100,12 @@ Resulting data model:
   │                                      │
   │   net.nordeck.barcamp.session_grid   │
   │                                      │
-  └──────────────────────────────────────┘
-       ▲
+  └────┬─────────────────────────────────┘
+       │
        │
        │ topicStartEventId
-       │
-  ┌────┴─────────────────────────────────┐
+       ▼
+  ┌──────────────────────────────────────┐
   │                                      │
   │net.nordeck.barcamp.session_grid.start│
   │                                      │


### PR DESCRIPTION
Signed-off-by: Kim Brose <2803622+HarHarLinks@users.noreply.github.com>

The diff algorithm is struggling, but it's actually just the direction of the arrow reversed as the "reference" is in the opposite direction than originally indicated.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [x] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
